### PR TITLE
LUT-26834: Add attribute type name in document type attribute creation page

### DIFF
--- a/src/java/fr/paris/lutece/plugins/document/web/DocumentTypeJspBean.java
+++ b/src/java/fr/paris/lutece/plugins/document/web/DocumentTypeJspBean.java
@@ -111,6 +111,7 @@ public class DocumentTypeJspBean extends PluginAdminPageJspBean
     private static final String MARK_ATTRIBUTE_TYPES_LIST = "attribute_types_list";
     private static final String MARK_DOCUMENT_TYPE_CODE = "document_type_code";
     private static final String MARK_ATTRIBUTE_TYPE_CODE = "attribute_type_code";
+    private static final String MARK_ATTRIBUTE_TYPE_NAME = "attribute_type_name";
     private static final String MARK_ATTRIBUTE_EXTRAS_PARAMETERS = "attribute_parameters";
     private static final String MARK_ATTRIBUTE = "attribute";
     private static final String MARK_METADATA_HANDLERS_LIST = "metadata_handlers_list";
@@ -342,6 +343,9 @@ public class DocumentTypeJspBean extends PluginAdminPageJspBean
             _attribute = new DocumentAttribute(  );
             model.put( MARK_ATTRIBUTE_EXTRAS_PARAMETERS, manager.getCreateParametersFormHtml( getLocale(  ) ) );
         }
+
+        ReferenceList listAttributeTypes = AttributeTypeHome.getAttributeTypesList( getLocale(  ) );
+        model.put(MARK_ATTRIBUTE_TYPE_NAME, listAttributeTypes.toMap( ).get(strAttributeTypeCode) );
 
         HtmlTemplate template = AppTemplateService.getTemplate( TEMPLATE_ADD_ATTRIBUTE, getLocale(  ), model );
 

--- a/webapp/WEB-INF/templates/admin/plugins/document/add_document_type_attribute.html
+++ b/webapp/WEB-INF/templates/admin/plugins/document/add_document_type_attribute.html
@@ -14,7 +14,7 @@
     <@pageColumn>
 		<@pageHeader title='#i18n{document.add_document_type_attribute.pageTitle}' />
 		<@tform method='post' name='docTypeAttr' action='jsp/admin/plugins/document/DoAddDocumentTypeAttribute.jsp' boxed=true>
-			<@fieldSet legend='#i18n{document.add_document_type_attribute.titleAddAttribute} ${name!}'>
+			<@fieldSet legend='#i18n{document.add_document_type_attribute.titleAddAttribute} ${attribute_type_name}'>
 				<@formGroup labelFor='name' labelKey='#i18n{document.add_document_type_attribute.labelName}' helpKey='#i18n{document.add_document_type_attribute.helpName}' mandatory=true>
 					<@input type='text' name='name' id='name' value='${name}' />
 				</@formGroup>


### PR DESCRIPTION
https://dev.lutece.paris.fr/bugtracker/issues/26834