### PR TITLE
LUT-33036 : remove jackson-mapper-asl 1.5.0 (migrate to Jackson 2.x)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,11 +46,6 @@
             <version>4.1</version>
             <type>jar</type>
         </dependency>
-		<dependency>
-			<groupId>org.codehaus.jackson</groupId>
-			<artifactId>jackson-mapper-asl</artifactId>
-			<version>1.5.0</version>
-		</dependency>
     </dependencies>
     <properties>
         <componentName>document</componentName>

--- a/src/java/fr/paris/lutece/plugins/document/service/attributes/DefaultManager.java
+++ b/src/java/fr/paris/lutece/plugins/document/service/attributes/DefaultManager.java
@@ -49,8 +49,8 @@ import fr.paris.lutece.util.html.HtmlTemplate;
 
 import org.apache.commons.lang3.StringUtils;
 
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.map.ObjectMapper;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 


### PR DESCRIPTION
## CVE-2017-7525 — remove jackson-mapper-asl 1.5.0

Redmine: LUT-33036

The plugin declares and uses the obsolete `org.codehaus.jackson:jackson-mapper-asl:1.5.0` (Jackson 1.x, unmaintained since ~2013), flagged by scanners under **CVE-2017-7525**. The v7 line — including this `develop_core7` branch (5.1.3-SNAPSHOT) — still ships it; only 6.0.0 (v8) removed it.

### Actual usage
A single usage point in `service/attributes/DefaultManager.java`: `new ObjectMapper().readTree(strValue)` (tree parsing, not polymorphic `readValue`), triggered only for a `geoloc` attribute bound to the `gismap` map provider.

### Change
- `DefaultManager`: `org.codehaus.jackson.JsonNode` / `ObjectMapper` → `com.fasterxml.jackson.databind.*` (identical `readTree`/`path` API).
- `pom.xml`: remove the `jackson-mapper-asl:1.5.0` dependency. Jackson 2.x is already provided transitively by lutece-core — **no new dependency added**.

---

## (Traduction française) CVE-2017-7525 — suppression de jackson-mapper-asl 1.5.0

Le plugin déclare et utilise la bibliothèque obsolète `org.codehaus.jackson:jackson-mapper-asl:1.5.0` (Jackson 1.x, non maintenue depuis ~2013), signalée par les scanners au titre de **CVE-2017-7525**. La ligne v7 — dont cette branche `develop_core7` (5.1.3-SNAPSHOT) — l'embarque toujours ; seule la 6.0.0 (v8) l'a retirée.

### Usage réel
Un seul point d'utilisation dans `service/attributes/DefaultManager.java` : `new ObjectMapper().readTree(strValue)` (parsing en arbre, pas de `readValue` polymorphe), déclenché uniquement pour un attribut `geoloc` associé au map provider `gismap`.

### Modification
- `DefaultManager` : `org.codehaus.jackson.JsonNode` / `ObjectMapper` → `com.fasterxml.jackson.databind.*` (API `readTree`/`path` identique).
- `pom.xml` : suppression de la dépendance `jackson-mapper-asl:1.5.0`. Jackson 2.x est déjà fourni transitivement par lutece-core — **aucune nouvelle dépendance ajoutée**.
