### PR TITLE
LUT-33040 : add plugin-xmltransformer dependency (core 7.1 XSL externalization)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,13 @@
             <version>[7.0.10,7.9.9)</version>
             <type>lutece-core</type>
         </dependency>
+        <!-- XSL/XML transformation services moved out of lutece-core (LUT-32172) -->
+        <dependency>
+            <groupId>fr.paris.lutece.plugins</groupId>
+            <artifactId>plugin-xmltransformer</artifactId>
+            <version>[1.0.0,1.9.9]</version>
+            <type>lutece-plugin</type>
+        </dependency>
         <!-- Add to resize image -->
         <dependency>
             <groupId>org.imgscalr</groupId>


### PR DESCRIPTION
## Adapt develop_core7 to core 7.1 XSL externalization

Redmine: LUT-33040

Since lutece-core commit `b6a32102a` — *"LUT-32172: Move XSL features and XML services to XML transformer plugin"* — the XSL/XML transformation classes were **removed from lutece-core** and moved to the dedicated `plugin-xmltransformer` plugin. As a result, `plugin-document` on `develop_core7` no longer compiled against a 7.1.x core: 4 classes still use `fr.paris.lutece.portal.service.html.XmlTransformerService` (`DocumentContentService`, `DocumentJspBean`, `DocumentContentJspBean`, `DocumentMetaPageInclude`).

### Change
- `pom.xml`: add the `plugin-xmltransformer` dependency with the v7 range `[1.0.0,1.9.9]` (the v7 line requires `lutece-core` 7.x; the 2.x line targets core 8).
- **No import change** — the classes kept the same package/FQN.
- `mvn clean compile` → **BUILD SUCCESS**.

---

## (Traduction française) Adapter develop_core7 à l'externalisation XSL du core 7.1

Depuis le commit lutece-core `b6a32102a` — *« LUT-32172 : Move XSL features and XML services to XML transformer plugin »* — les classes de transformation XSL/XML ont été **retirées de lutece-core** vers le plugin dédié `plugin-xmltransformer`. En conséquence, `plugin-document` sur `develop_core7` ne compilait plus avec un core 7.1.x : 4 classes utilisent encore `fr.paris.lutece.portal.service.html.XmlTransformerService` (`DocumentContentService`, `DocumentJspBean`, `DocumentContentJspBean`, `DocumentMetaPageInclude`).

### Modification
- `pom.xml` : ajout de la dépendance `plugin-xmltransformer` avec la plage v7 `[1.0.0,1.9.9]` (la ligne v7 requiert `lutece-core` 7.x ; la ligne 2.x cible le core 8).
- **Aucun changement d'import** — les classes ont conservé le même package/FQN.
- `mvn clean compile` → **BUILD SUCCESS**.
